### PR TITLE
Fix for incorrent errors about non-empty output directory

### DIFF
--- a/src/wdm/debian/Packager.php
+++ b/src/wdm/debian/Packager.php
@@ -108,7 +108,7 @@ class Packager
         if (file_exists($this->getOutputPath())) {
             $iterator = new \DirectoryIterator($this->getOutputPath());
             foreach ($iterator as $path) {
-                if ($path != '.' || $path != '..') {
+                if ($path != '.' && $path != '..') {
                     echo "OUTPUT DIRECTORY MUST BE EMPTY! Something exists, exit immediately!" . PHP_EOL;
                     exit();
                 }


### PR DESCRIPTION
Sometimes I get this error complaining about non-empty output directory, which was actually empty.
Now I see what was behind this error.

If directory empty, it contains only "." and "..". On first run "." is used and result of `($path != '.' || $path != '..')` is true. So `||` changed to `&&` fixes this bug.