### PR TITLE
improve symlink copying

### DIFF
--- a/src/wdm/debian/Packager.php
+++ b/src/wdm/debian/Packager.php
@@ -179,13 +179,14 @@ class Packager
         if (!file_exists($destFolder)) {
             mkdir($destFolder, 0777, true);
         }
-	if (is_link($source)){
-	    symlink(readlink($source), $dest);
-	} else {
+        if (is_link($source)) {
+            symlink(readlink($source), $dest);
+        } else {
             copy($source, $dest);
-	}
-        if (fileperms($source) != fileperms($dest))
+        }
+        if (fileperms($source) != fileperms($dest)) {
             chmod($dest, fileperms($source));
+        }
     }
 
     public function build($debPackageName = false)

--- a/src/wdm/debian/Packager.php
+++ b/src/wdm/debian/Packager.php
@@ -182,7 +182,10 @@ class Packager
         if (is_link($source)) {
             symlink(readlink($source), $dest);
         } else {
-            copy($source, $dest);
+            if(!copy($source, $dest)) {
+                echo "Error: failed to copy: $source -> $dest \m";
+                return;
+            }
         }
         if (fileperms($source) != fileperms($dest)) {
             chmod($dest, fileperms($source));

--- a/src/wdm/debian/Packager.php
+++ b/src/wdm/debian/Packager.php
@@ -181,6 +181,7 @@ class Packager
         }
         if (is_link($source)) {
             symlink(readlink($source), $dest);
+            return; // don't set perms on symlink targets
         } else {
             if(!copy($source, $dest)) {
                 echo "Error: failed to copy: $source -> $dest \m";


### PR DESCRIPTION
When copying a symlink, the target may be outside of our package (or invalid) - so don't try setting the permissions on it.