### PR TITLE
Fix spacing in method names

### DIFF
--- a/src/wdm/debian/control/StandardFile.php
+++ b/src/wdm/debian/control/StandardFile.php
@@ -149,12 +149,12 @@ class StandardFile
         return $this;
     }
 
-    public function offsetExists ($offset)
+    public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->_keys);
     }
 
-    public function offsetGet ($offset)
+    public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
             return $this->_keys[$offset];
@@ -163,7 +163,7 @@ class StandardFile
         }
     }
 
-    public function offsetSet ($offset, $value)
+    public function offsetSet($offset, $value)
     {
         if (!$this->offsetExists($offset)) {
             throw new \InvalidArgumentException("Invalid property '{$offset}' for this control file.");
@@ -171,7 +171,7 @@ class StandardFile
         $this->_keys[$offset] = $value;
     }
 
-    public function offsetUnset ($offset)
+    public function offsetUnset($offset)
     {
         if ($this->offsetExists($offset)) {
             unset($this->_keys[$offset]);


### PR DESCRIPTION
Some method names were followed by spaces.