### PR TITLE
fix composer.json (vfsStream -> vfsstream)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4",
-        "mikey179/vfsStream": "1.4.*"
+        "mikey179/vfsstream": "1.4.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Composer (2?) moans with 

                                                                               
  [RuntimeException]                                                           
  require-dev.mikey179/vfsStream is invalid, it should not contain uppercase   
  characters. Please use mikey179/vfsstream instead.                           
                                                        

this fixes it.